### PR TITLE
Revert the filename to not break the scf repo

### DIFF
--- a/packages/opensuse42/packaging
+++ b/packages/opensuse42/packaging
@@ -1,4 +1,4 @@
 set -e -x
 
 echo "Copying rootfs"
-cp rootfs/cf-opensuse42-*.tar.gz ${BOSH_INSTALL_TARGET}/cf-opensuse42.tar.gz
+cp rootfs/cf-opensuse42-*.tar.gz ${BOSH_INSTALL_TARGET}/opensuse42.tar.gz

--- a/packages/opensuse42/spec
+++ b/packages/opensuse42/spec
@@ -1,4 +1,4 @@
 ---
-name: cf-opensuse42
+name: opensuse42
 files:
 - rootfs/cf-opensuse42-*.tar.gz


### PR DESCRIPTION
The purpose of this change it to avoid changes on the scf repo (which is out of scope for the current work). This PR should keep the release buildable and consumable as it is on the `scf` side.